### PR TITLE
issue91 clearing session table after each test | Approach 'A'

### DIFF
--- a/test/manager.js
+++ b/test/manager.js
@@ -11,6 +11,10 @@ var bcrypt = require('bcrypt-nodejs');
 var app = require('../index');
 var db = app.db;
 
+var session = require('express-session');
+var MySQLStore = require('express-mysql-session')(session);
+var sessionStore = new MySQLStore(app.config.db);
+
 var manager = module.exports = {
 
 	// Wait for the app to be ready.
@@ -40,7 +44,10 @@ var manager = module.exports = {
 
 	tearDown: function(cb) {
 
-		manager.dropDatabaseTables(cb);
+		async.series([
+			manager.dropDatabaseTables,
+			manager.clearSessions
+		], cb)
 	},
 
 	dropDatabaseTables: function(cb) {
@@ -72,5 +79,10 @@ var manager = module.exports = {
 					.catch(cb);
 			});
 		});
+	},
+
+	clearSessions: function(cb) {
+		sessionStore.clear();
+		cb();
 	}
 };


### PR DESCRIPTION
Approach A for:
- Modified tearDown function in 'test/manager.js' to clear sessions as suggested using 'express-session' module.

It is working ok like this, but I am not completely sure if the approach of  using the global variable 'app'
instead of the declaring varibles below is better, so I will create other pull request with the other approach.
```javascript

var session = require('express-session');
var MySQLStore = require('express-mysql-session')(session);
var sessionStore = new MySQLStore(app.config.db);
```
